### PR TITLE
fix: resolve PowerShell -Verbose parameter conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- PowerShell `-Verbose` parameter conflict: removed explicit `[switch]$Verbose` declaration that clashed with the common parameter provided by `[CmdletBinding()]`; `Write-VerboseMessage` now checks `$VerbosePreference` instead
+
 ## [1.2.0] - 2026-02-22
 
 ### Added

--- a/setup.ps1
+++ b/setup.ps1
@@ -12,7 +12,6 @@ param(
     [switch]$Uninstall,
     [string]$Path,
     [switch]$DryRun,
-    [switch]$Verbose,
     [switch]$Quiet,
     [switch]$Backup,
     [switch]$Version,
@@ -89,7 +88,7 @@ function Write-InfoMessage {
 
 function Write-VerboseMessage {
     param([string]$Message)
-    if ($Verbose) {
+    if ($VerbosePreference -ne 'SilentlyContinue') {
         Write-Host "  -> " -ForegroundColor DarkGray -NoNewline
         Write-Host $Message -ForegroundColor DarkGray
     }


### PR DESCRIPTION
## What

Removed the explicit `[switch]$Verbose` declaration from `setup.ps1`'s `param()` block.

## Why

`[CmdletBinding()` automatically injects PowerShell's common parameters — including `-Verbose` — into every advanced function and script. Declaring `[switch]$Verbose` explicitly inside the same `param()` block causes PowerShell to throw a fatal error at parse time:
```
A parameter with the name 'Verbose' was defined multiple times for the command.
```
This made the script completely unusable, even for a simple .\setup.ps1 --dry-run.

## Fix

- Removed [switch]$Verbose from the param() block.
- Updated Write-VerboseMessage to check $VerbosePreference directly instead of a custom $Verbose switch, which is the idiomatic PowerShell way to respect the built-in -Verbose flag.