### PR TITLE
fix: detect Claude Desktop installed via Windows Store (MSIX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - PowerShell `-Verbose` parameter conflict: removed explicit `[switch]$Verbose` declaration that clashed with the common parameter provided by `[CmdletBinding()]`; `Write-VerboseMessage` now checks `$VerbosePreference` instead
+- Claude Desktop installed via Windows Store (MSIX) is now detected automatically (#7)
 
 ## [1.2.0] - 2026-02-22
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -157,6 +157,23 @@ function Get-ClaudeNativeHostPath {
             return $p
         }
     }
+
+    # Fallback: MSIX / Windows Store installation
+    # Package folders use the pattern Claude_<publisherHash>
+    $msixBase = "$env:LOCALAPPDATA\Packages"
+    if (Test-Path $msixBase) {
+        $claudePkg = Get-ChildItem -Path $msixBase -Directory -Filter "Claude_*" |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+        if ($claudePkg) {
+            $msixPath = Join-Path $claudePkg.FullName "LocalCache\Roaming\Claude\ChromeNativeHost\chrome-native-host.exe"
+            if (Test-Path $msixPath) {
+                Write-VerboseMessage "Found Claude Desktop (Windows Store) at: $msixPath"
+                return $msixPath
+            }
+        }
+    }
+
     return $null
 }
 


### PR DESCRIPTION
## Summary
- Adds MSIX package path fallback to `Get-ClaudeNativeHostPath`
- Windows Store installations live under `%LOCALAPPDATA%\Packages\Claude_<hash>\LocalCache\` instead of the traditional installer paths
- Resolves package folder safely via `Get-ChildItem -Filter`, picks the most recent if multiple exist, validates executable before returning

Closes #7

## Test plan
- [ ] Verify on Windows with traditional Claude Desktop install (no regression)
- [ ] Verify on Windows with Windows Store (MSIX) Claude Desktop install
- [ ] Verify `-Verbose` shows the detected MSIX path

Thanks to @zwinglio for reporting and documenting the root cause and correct MSIX path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)