### PR TITLE
feat(vivaldi): fix "No active tab" with a tab-binding patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Vivaldi tab-binding patch** — fixes the `No active tab` error that made the Web Panel workaround render but never send
+  - `patch-vivaldi.sh` (macOS/Linux) and `patch-vivaldi.ps1` (Windows) build a patched, unpacked copy of the Claude extension with a wrapper service worker (`tabbind.js`) that keeps `chrome.storage.local["targetTabId"]` pointing at the active tab
+  - The wrapper `import`s the original service worker untouched, so no extension code is rewritten; `"key"` is preserved so the extension ID — and therefore the native messaging manifests written by `setup.sh` — stay valid
+  - `--check` reports version drift after the Web Store copy auto-updates; `--uninstall` removes the patched copy; `--dry-run`, `--verbose`, `--quiet`, `--source`, `--dest`, `--browser`, `--profile` supported
+  - `docs/vivaldi-tab-binding.md` — root-cause analysis, design notes, verification steps, and the upstream fix that would make the patch unnecessary
+  - `tests/test_patch_vivaldi.sh` — 55 tests covering manifest rewriting, wrapper generation, version selection, drift detection, and destination safety guards
+  - Diagnosis contributed by a user who traced it through the deminified extension bundle; re-verified against Claude extension 1.0.84
+
 ### Changed
 - **Linux: Replaced Direct API Mode with Claude Code CLI integration**
   - Linux now uses Claude Code CLI's native messaging host (`~/.claude/chrome/chrome-native-host`) instead of a custom Node.js API host

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ See [`docs/linux-setup.md`](docs/linux-setup.md) for detailed instructions and t
 - **Interactive Setup** - Select which browsers to configure
 - **JSON Configuration** - Easy to extend with new browsers
 - **Test Suite** - Automated tests for reliability
+- **Vivaldi Tab-Binding Patch** - Fixes the `No active tab` error in browsers that ignore `chrome.sidePanel.setOptions()` ([details](#vivaldi-no-active-tab))
 
 ## The Problem
 
@@ -177,7 +178,7 @@ These browsers work with native messaging but have known caveats:
 
 | Browser | Engine | macOS | Linux | Windows | Notes |
 |---------|--------|:-----:|:-----:|:-------:|-------|
-| **Vivaldi** | Chromium | ⚠️ | ⬜ | ⬜ | Blank side panel on macOS ([details](#vivaldi-blank-side-panel)) |
+| **Vivaldi** | Chromium | ⚠️ | ⬜ | ⬜ | Blank side panel, then `No active tab` — both fixable with `patch-vivaldi.sh` ([details](#vivaldi-no-active-tab)) |
 | **Chromium (Snap)** | Chromium | — | ❌ | — | Snap sandbox blocks native messaging ([details](#chromium-snap-on-linux)) |
 
 ### Should Work (Chromium-based, not yet confirmed)
@@ -421,17 +422,21 @@ claude-chromium-native-messaging/
 ├── setup.ps1                       # Windows setup
 ├── install-linux.sh                # Linux quick installer (extends Claude Code)
 ├── uninstall-linux.sh              # Linux uninstaller
+├── patch-vivaldi.sh                # Vivaldi/Arc tab-binding patch (macOS/Linux)
+├── patch-vivaldi.ps1               # Vivaldi tab-binding patch (Windows)
 ├── config/
 │   └── browsers.json               # Browser paths & extension IDs
 ├── tests/
 │   ├── test_setup.sh               # Bash test suite (52 tests)
 │   ├── test_browser_detection.sh   # Browser detection tests (76 tests)
+│   ├── test_patch_vivaldi.sh       # Vivaldi patch tests
 │   ├── test_setup.ps1              # PowerShell tests
 │   ├── setup.Tests.ps1             # Pester tests (Windows)
 │   └── fixtures/                   # Test data files
 ├── docs/
 │   ├── manual-setup.md             # Manual setup guide
-│   └── linux-setup.md              # Linux-specific guide
+│   ├── linux-setup.md              # Linux-specific guide
+│   └── vivaldi-tab-binding.md      # "No active tab" analysis & patch design
 ├── CHANGELOG.md
 ├── CONTRIBUTING.md
 ├── TESTING.md                      # Test suite documentation
@@ -460,9 +465,9 @@ Arc does not implement Chrome's `chrome.sidePanel` API. This means:
 
 **Vivaldi Blank Side Panel**
 
-Native messaging installs correctly in Vivaldi on macOS, but clicking the Claude extension icon opens a blank side panel. This is a Vivaldi-specific bug — Vivaldi's `chrome.sidePanel` API implementation does not render extension content. The extension itself is fully functional; it just can't render through Vivaldi's native side panel mechanism.
+Native messaging installs correctly in Vivaldi, but clicking the Claude extension icon opens a blank side panel. This is a Vivaldi-specific bug — Vivaldi's `chrome.sidePanel` API implementation does not render extension content. The extension itself is fully functional; it just can't render through Vivaldi's native side panel mechanism.
 
-**Confirmed workaround: use Vivaldi's Web Panel**
+**Workaround: use Vivaldi's Web Panel**
 
 1. Navigate to the extension URL in a regular tab:
    ```
@@ -473,9 +478,56 @@ Native messaging installs correctly in Vivaldi on macOS, but clicking the Claude
 4. In Vivaldi's left sidebar, click **+** (Add Web Panel) and paste the URL
 5. Claude now lives permanently in Vivaldi's sidebar as a Web Panel
 
-**What works in Vivaldi:** Full Claude interface, Claude Desktop native messaging, all AI features — via the Web Panel workaround above.
+This makes the panel **render**, but on its own it is not enough to make it work — see the next section.
 
 **What doesn't work:** Opening Claude via the extension toolbar icon (the `chrome.sidePanel` API is broken in Vivaldi).
+
+---
+
+**Vivaldi: "No active tab"**
+
+With the Web Panel workaround above, the panel renders and logs in, but every message fails silently: the composer clears and nothing is sent. The panel console shows:
+
+```
+Uncaught (in promise) Error: No active tab
+```
+
+**Cause:** the panel resolves its target tab from exactly two places — a `?tabId=N` query parameter, or `chrome.storage.local["targetTabId"]` when opened with `?mode=window`. In Chrome the service worker injects the tab ID into the panel URL per tab via `chrome.sidePanel.setOptions()`. Vivaldi ignores `setOptions()`, and a Web Panel URL is a frozen string, so neither source is populated and the send path throws. Full analysis: [docs/vivaldi-tab-binding.md](docs/vivaldi-tab-binding.md).
+
+**Fix:** `patch-vivaldi.sh` builds a patched, unpacked copy of the extension that keeps `targetTabId` pointing at the active tab.
+
+```bash
+# macOS / Linux
+./patch-vivaldi.sh
+
+# Windows
+.\patch-vivaldi.ps1
+```
+
+The script copies the store copy of the extension to `~/claude-vivaldi-patched`, adds a wrapper service worker (`tabbind.js`) that imports the original untouched and appends the missing `chrome.tabs` listeners, and points `manifest.json` at it. The `"key"` field is preserved, so the extension ID stays `fcoeoabgfenejglbffodgkkbkcdhcgfn` and the native messaging manifests written by `setup.sh` keep working with no changes.
+
+Three steps have to be done by hand afterwards:
+
+1. `vivaldi://extensions` → **disable** (do not remove) the Web Store copy. Both copies claim the same ID, so leaving it enabled causes a duplicate-ID error. Leaving it installed but disabled keeps it auto-updating as the source for re-patching.
+2. Turn on **Developer mode** → **Load unpacked** → select `~/claude-vivaldi-patched`
+3. Add the Web Panel with this URL — **the query string is required**:
+   ```
+   chrome-extension://fcoeoabgfenejglbffodgkkbkcdhcgfn/sidepanel.html?mode=window&sessionId=vivaldi-panel
+   ```
+
+The patched copy is a snapshot, so re-run the script when the store copy updates:
+
+```bash
+./patch-vivaldi.sh --check   # exit 0 = up to date, 1 = stale
+./patch-vivaldi.sh           # rebuild
+./patch-vivaldi.sh --uninstall
+```
+
+**What works in Vivaldi after patching:** Full Claude interface, Claude Desktop native messaging, chat, and page context for the bound tab.
+
+**Caveat:** the panel reads the tab binding once, when the panel document loads. Reload the Web Panel to re-bind it to the current tab.
+
+> The real fix belongs upstream — a third fallback branch in the panel's tab resolver would fix Vivaldi, Arc, and every other Chromium fork at once. See [docs/vivaldi-tab-binding.md](docs/vivaldi-tab-binding.md#upstream).
 
 ---
 
@@ -652,6 +704,8 @@ To find the correct path, open your browser and navigate to `chrome://version` �
 ```bash
 # Bash tests
 ./tests/test_setup.sh
+./tests/test_browser_detection.sh
+./tests/test_patch_vivaldi.sh
 
 # PowerShell tests
 .\tests\test_setup.ps1

--- a/TESTING.md
+++ b/TESTING.md
@@ -10,13 +10,16 @@ The test suite validates browser detection, path validation, config file handlin
 
 ```bash
 # Run all tests
-bash tests/test_setup.sh && bash tests/test_browser_detection.sh
+bash tests/test_setup.sh && bash tests/test_browser_detection.sh && bash tests/test_patch_vivaldi.sh
 
 # Run only the core test suite
 bash tests/test_setup.sh
 
 # Run only browser detection integration tests
 bash tests/test_browser_detection.sh
+
+# Run only the Vivaldi tab-binding patch tests
+bash tests/test_patch_vivaldi.sh
 ```
 
 ### PowerShell Tests (Windows)
@@ -66,6 +69,20 @@ Comprehensive integration tests for browser detection logic:
 | Chrome Beta/Dev | 2 | Beta and Dev channel detection |
 | Config completeness | 3 | Built-in count, JSON/built-in match, non-empty names |
 | Claude Code host path | 2 | Path return without existence check (documented issue) |
+
+### `tests/test_patch_vivaldi.sh` (55 tests)
+
+Tests for `patch-vivaldi.sh`, run against a synthetic extension fixture so no
+real browser profile is touched:
+
+| Category | What It Covers |
+|----------|----------------|
+| Script sanity | Executable bit, help contents, unknown options, mutually exclusive flags |
+| Dry run | Labelled output, writes nothing to disk |
+| Patch output | Wrapper generation, manifest rewriting (`service_worker`, `type`, `update_url`), `key` preservation, `_metadata` removal, `patch-info.json` |
+| JSON backends | Every assertion above runs once per available backend (python3 and jq) |
+| Safety guards | Refuses an already-patched source, refuses to delete a destination that is not an extension |
+| Version handling | Numeric version-folder sorting (1.0.84 > 1.0.9), `--check` up-to-date and drift detection, `--uninstall` |
 
 ### `tests/test_setup.ps1` (12 tests)
 
@@ -132,6 +149,7 @@ Tests can run in any CI environment with Bash 4.0+ and jq. No real browser insta
   run: |
     bash tests/test_setup.sh
     bash tests/test_browser_detection.sh
+    bash tests/test_patch_vivaldi.sh
 ```
 
 Tests that require `jq` will be skipped (not failed) if jq is unavailable.

--- a/docs/vivaldi-tab-binding.md
+++ b/docs/vivaldi-tab-binding.md
@@ -1,0 +1,258 @@
+# Vivaldi: "No active tab" — root cause and fix
+
+The README's Web Panel workaround gets the Claude panel to **render** in Vivaldi,
+but the panel is not functional: typing a message and pressing Enter clears the
+composer and nothing is sent. The panel console shows:
+
+```
+Uncaught (in promise) Error: No active tab
+    at assets/sidepanel-<hash>.js
+```
+
+This document explains why, and what `patch-vivaldi.sh` / `patch-vivaldi.ps1` do
+about it.
+
+**Credit:** the diagnosis below was contributed by a user who traced it through
+the deminified extension bundle on macOS. It was independently re-verified
+against Claude extension `1.0.84` (`fcoeoabgfenejglbffodgkkbkcdhcgfn`) as
+installed by Vivaldi stable.
+
+## Not the cause
+
+Each of these was tested and eliminated, so nobody has to repeat the work:
+
+| Hypothesis | Evidence against |
+|---|---|
+| A Web Panel isn't a real extension context | `chrome.runtime.id` returns the correct ID; `typeof chrome.tabs` is `"object"`; `chrome.runtime.sendMessage({ping:1})` resolves |
+| Service worker dead or unregistered | The worker is alive and logging; `chrome.tabs.onActivated` listeners fire normally |
+| CSP inline-script failure ([claude-code#35871](https://github.com/anthropics/claude-code/issues/35871)) | The panel initialises fine; unrelated to the submit path |
+| Tracker blocking (`api.segment.io` → `ERR_BLOCKED_BY_CLIENT`) | Telemetry only; does not gate submit |
+| Bridge feature flag (`chrome_ext_bridge_enabled`) | The extension *does* attempt `wss://bridge.claudeusercontent.com`; unrelated to chat |
+| Focus-based tab lookup | `lastFocusedWindow` appears nowhere in the extension bundle |
+| Panel is its own window, breaking `currentWindow` | From the panel context, `chrome.windows.getCurrent` returns the normal browser window, and `chrome.tabs.query({active:true, currentWindow:true})` correctly returns the active tab |
+
+## Root cause
+
+### The panel resolves its tab from exactly two sources
+
+Deminified from `assets/sidepanel-<hash>.js`, running once in a `useEffect` at
+mount:
+
+```js
+const e = new URLSearchParams(window.location.search), i = e.get("tabId");
+let o;
+if (i) {
+  o = parseInt(i);
+} else if ("window" === e.get("mode")) {
+  const e = await $(A.TARGET_TAB_ID);   // chrome.storage.local, key "targetTabId"
+  e && (o = e);
+}
+s(o);   // → React state, referenced downstream as `l`
+```
+
+Two branches, no fallback. There is no `chrome.tabs.query` path.
+
+### The guard that throws
+
+```js
+dt = useCallback(async (e, t, s, a, c, d = false) => {
+  if (!we.current) throw new Error("Client not initialized");
+  if (!l)          throw new Error("No active tab");
+  ...
+```
+
+`l` is used downstream as `await chrome.tabs.get(l)`,
+`H.getValidTabsWithMetadata(l)`, and `J(Ie.current, {tabId: l})`. The throw
+surfaces at click time, but the cause is at load time.
+
+### Why the Web Panel never populates it
+
+In Chrome, the service worker injects the tab ID into the panel URL, per tab:
+
+```js
+chrome.sidePanel.setOptions({
+  tabId: e,
+  path: `sidepanel.html?tabId=${encodeURIComponent(e)}`,
+  enabled: true,
+});
+```
+
+Vivaldi ignores `chrome.sidePanel.setOptions` ([VB-120826]). The README's Web
+Panel workaround sidesteps that by loading `sidepanel.html` directly — but that
+is a frozen string with no query parameters. In the panel console,
+`location.search` is `""`.
+
+So `tabId` is absent (branch 1 skipped), `mode` is absent (branch 2 skipped),
+the tab ID stays `undefined`, and every send throws.
+
+### The second branch is a real, usable code path
+
+`TARGET_TAB_ID` is `chrome.storage.local` key `"targetTabId"`. The stock
+extension writes it in exactly one place — the scheduled-task launcher in the
+service worker, which writes it once when it opens a dedicated task window:
+
+```js
+await m.createGroup(o.id);
+await d(i.TARGET_TAB_ID, o.id);
+const o = chrome.runtime.getURL(`sidepanel.html?mode=window&sessionId=${t}...`);
+await chrome.windows.create({ ... });
+```
+
+Nothing keeps it current — there is no `tabs.onActivated` listener anywhere in
+the service worker bundle. That is the only gap between the existing code path
+and a working Vivaldi panel.
+
+## Why the other workarounds don't fix it
+
+- **Web Panel with a bare URL** (the previous README advice) — this *is* the bug.
+- **Static `side_panel.default_path` manifest patch**
+  ([bigbrojake/claude-extension-vivaldi-fix]) — fixes *rendering* via Vivaldi's
+  native side panel, but a static manifest path has no query string by
+  definition, so it lands on the same `No active tab` throw.
+- **Appending `?tabId=<n>` by hand** — works, but pins the panel to one tab ID,
+  and tab IDs are regenerated on browser restart.
+
+## The fix
+
+Two parts, both applied by `patch-vivaldi.sh` (and `patch-vivaldi.ps1`):
+
+**1. Open the panel on the `mode=window` branch:**
+
+```
+chrome-extension://fcoeoabgfenejglbffodgkkbkcdhcgfn/sidepanel.html?mode=window&sessionId=vivaldi-panel
+```
+
+`sessionId` is not needed for chat, but `EXECUTE_TASK` routing bails on
+`mode=window` without one, so it is cheap to satisfy.
+
+**2. Keep `targetTabId` current** with a wrapper service worker.
+
+MV3 allows exactly one service worker, so the patch does not replace the
+extension's worker — it adds `tabbind.js`, which `import`s the original
+untouched and appends the listeners the stock build lacks:
+
+```js
+import './service-worker-loader.js';
+
+chrome.tabs.onActivated.addListener(({ tabId }) => bindIfWebTab(tabId));
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => { ... });
+chrome.windows.onFocusChanged.addListener(...);
+chrome.runtime.onStartup.addListener(bindActiveTab);
+void bindActiveTab();
+```
+
+and points `manifest.json` at it.
+
+`chrome.tabs.onActivated` does fire correctly in Vivaldi:
+
+```
+activated {tabId: 1990186690, windowId: 1990184788}
+activated {tabId: 1990185069, windowId: 1990184788}
+```
+
+### Design notes
+
+- **Loader wrapper, not replacement.** `"background": {"type": "module"}` is
+  required for the `import` — the stock manifest already sets it.
+- **`"key"` is preserved**, so the unpacked copy keeps extension ID
+  `fcoeoabgfenejglbffodgkkbkcdhcgfn` and the native messaging manifests written
+  by `setup.sh` keep matching it. No reconfiguration needed.
+- **`update_url` is removed** so the browser does not try to auto-update an
+  unpacked extension.
+- **`_metadata/` is removed** — those are Web Store signatures that do not apply
+  to an unpacked copy.
+- **`https?:` guard** avoids binding to `vivaldi://`, `chrome-extension://`, or
+  blank tabs.
+- **Binds on worker wake, not just on tab switch** — tab IDs are regenerated on
+  browser restart, so waiting for the first tab switch would leave a stale ID in
+  storage.
+- **`chrome.storage.local` only.** The panel and the worker both read and write
+  `local`; neither uses `session` or `sync`.
+
+### Freshness caveat
+
+The panel reads `targetTabId` **once, when the panel document loads** — there is
+no `storage.onChanged` listener for that key in the panel bundle. So the patch
+guarantees that a panel loaded now binds to the tab that is active now; it does
+not retarget a panel that is already open. Reload the Web Panel to re-bind it to
+the current tab.
+
+This mirrors Chrome, where the side panel is per-tab by construction.
+
+## Manual steps (can't be scripted)
+
+1. `vivaldi://extensions` → **disable** (do not remove) the Web Store copy. Both
+   copies claim the same ID, so leaving it enabled causes a duplicate-ID error.
+   Leaving it installed-but-disabled is deliberate: it keeps auto-updating and
+   serves as the source for re-patching.
+2. Developer mode ON → **Load unpacked** → the patched folder.
+3. Add the Web Panel with the `?mode=window&sessionId=vivaldi-panel` URL above.
+
+## Verification
+
+From the extension's service worker console (`vivaldi://extensions` → the
+unpacked Claude entry → **service worker**):
+
+```js
+chrome.storage.local.get('targetTabId').then(console.log)
+```
+
+The value should change as you switch tabs. Then reload the Web Panel on a
+different site and ask Claude what page you are on — it should name the new
+page. Restart Vivaldi and repeat, to confirm the `onStartup` path.
+
+## Version drift
+
+The patched copy is a snapshot. When the disabled store copy auto-updates, the
+patched copy is left behind:
+
+```bash
+./patch-vivaldi.sh --check   # exit 0 = up to date, 1 = stale
+./patch-vivaldi.sh           # rebuild
+```
+
+The script derives the worker filename from `manifest.json` rather than
+hardcoding a build hash, so re-running is all that is needed.
+
+## Upstream
+
+The real fix belongs in the extension — a third fallback branch in the resolver:
+
+```js
+if (i) o = parseInt(i);
+else if ("window" === e.get("mode")) { /* storage */ }
+else { const [t] = await chrome.tabs.query({active:true, currentWindow:true}); o = t?.id; }
+```
+
+`currentWindow` demonstrably resolves correctly from the panel document context
+in Vivaldi. Three lines upstream would fix Vivaldi, Arc, and every other fork at
+once, and make this patch unnecessary.
+
+## Open questions
+
+- **Other forks.** Any Chromium fork that ignores dynamic `setOptions` hits this
+  identically. Arc is the obvious candidate — [Zu9zwan9/claude-in-arc] solves it
+  with a `chrome.sidePanel` polyfill that opens a popup window, which is heavier
+  than this patch. Whether `mode=window` + storage binding is a simpler
+  universal answer is untested; `patch-vivaldi.sh --browser arc` exists so it
+  can be tried.
+- **Tab grouping.** The scheduled-task launcher calls `createGroup()` before
+  writing `TARGET_TAB_ID`, and the resolver follows with `isInGroup()` /
+  `isMainTab()`. Chat works without a group, but tab-orchestration features may
+  expect one. Untested.
+- **`chrome_ext_bridge_enabled`.** The extension *attempted* the
+  `wss://bridge.claudeusercontent.com` connection during diagnosis (it failed on
+  local DNS), which suggests the flag may not be `false` for Vivaldi as the
+  README states elsewhere. Worth re-checking independently.
+
+## Related
+
+- [claude-code#30873](https://github.com/anthropics/claude-code/issues/30873) — shows the `setOptions({tabId, path: 'sidepanel.html?tabId=...'})` call
+- [claude-code#34062](https://github.com/anthropics/claude-code/issues/34062) — Vivaldi extension rendering failure
+- [claude-code#35871](https://github.com/anthropics/claude-code/issues/35871) — CSP + "Receiving end does not exist" (distinct issue)
+- [bigbrojake/claude-extension-vivaldi-fix] — static `default_path` rendering fix
+- [Zu9zwan9/claude-in-arc] — `chrome.sidePanel` polyfill approach
+
+[VB-120826]: https://bugs.vivaldi.com/
+[bigbrojake/claude-extension-vivaldi-fix]: https://github.com/bigbrojake/claude-extension-vivaldi-fix
+[Zu9zwan9/claude-in-arc]: https://github.com/Zu9zwan9/claude-in-arc

--- a/patch-vivaldi.ps1
+++ b/patch-vivaldi.ps1
@@ -1,0 +1,553 @@
+# Claude Extension Tab-Binding Patch for Vivaldi (Windows)
+#
+# Builds a patched, unpacked copy of the Claude extension for Chromium forks
+# that ignore chrome.sidePanel.setOptions() - Vivaldi (VB-120826), Arc, and
+# friends. Those browsers can only load the panel from a static URL, which
+# leaves the panel with no target tab and makes every message fail with
+# "No active tab".
+#
+# See docs/vivaldi-tab-binding.md for the full analysis.
+#
+# Usage: .\patch-vivaldi.ps1 [OPTIONS]
+# Run .\patch-vivaldi.ps1 -Help for more information.
+
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param(
+    [string]$Browser = "vivaldi",
+    [string]$BrowserProfile = "Default",
+    [string]$Source,
+    [string]$Dest,
+    [string]$ExtensionId = "fcoeoabgfenejglbffodgkkbkcdhcgfn",
+    [switch]$Check,
+    [switch]$Uninstall,
+    [switch]$DryRun,
+    [switch]$Quiet,
+    [switch]$Version,
+    [switch]$Help
+)
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+$script:ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$script:ScriptName = Split-Path -Leaf $MyInvocation.MyCommand.Path
+$script:VersionFile = Join-Path $ScriptDir "VERSION"
+
+# Name of the wrapper service worker written into the patched copy
+$script:WrapperWorker = "tabbind.js"
+
+# Metadata file recorded in the patched copy (used by -Check)
+$script:PatchInfo = "patch-info.json"
+
+# Query string the panel must be opened with (see docs/vivaldi-tab-binding.md)
+$script:PanelQuery = "?mode=window&sessionId=vivaldi-panel"
+
+if (-not $Dest) {
+    $Dest = Join-Path $env:USERPROFILE "claude-vivaldi-patched"
+}
+$Dest = $Dest.TrimEnd('\', '/')
+
+# =============================================================================
+# Output Functions
+# =============================================================================
+
+function Get-ScriptVersion {
+    if (Test-Path $script:VersionFile) {
+        return (Get-Content $script:VersionFile -Raw).Trim()
+    }
+    return "unknown"
+}
+
+function Write-Header {
+    if ($Quiet) { return }
+    Write-Host ""
+    Write-Host "===========================================================" -ForegroundColor Cyan
+    Write-Host "  Claude Extension Tab-Binding Patch (Vivaldi / Arc)" -ForegroundColor Cyan
+    Write-Host "  Version: $(Get-ScriptVersion)" -ForegroundColor Cyan
+    Write-Host "===========================================================" -ForegroundColor Cyan
+    Write-Host ""
+}
+
+function Write-SuccessMessage {
+    param([string]$Message)
+    if ($Quiet) { return }
+    Write-Host "OK " -ForegroundColor Green -NoNewline
+    Write-Host $Message
+}
+
+function Write-ErrorMessage {
+    param([string]$Message)
+    Write-Host "X " -ForegroundColor Red -NoNewline
+    Write-Host $Message
+}
+
+function Write-WarningMessage {
+    param([string]$Message)
+    if ($Quiet) { return }
+    Write-Host "! " -ForegroundColor Yellow -NoNewline
+    Write-Host $Message
+}
+
+function Write-InfoMessage {
+    param([string]$Message)
+    if ($Quiet) { return }
+    Write-Host "i " -ForegroundColor Cyan -NoNewline
+    Write-Host $Message
+}
+
+function Write-DryRunMessage {
+    param([string]$Message)
+    Write-Host "[DRY-RUN] " -ForegroundColor Yellow -NoNewline
+    Write-Host $Message
+}
+
+function Show-Help {
+    @"
+Claude Extension Tab-Binding Patch v$(Get-ScriptVersion)
+
+Builds a patched, unpacked copy of the Claude extension so that the side panel
+can resolve a target tab in browsers that ignore chrome.sidePanel.setOptions().
+
+Without this patch the panel renders but every message fails with
+"No active tab" (see docs/vivaldi-tab-binding.md).
+
+USAGE:
+    .\$($script:ScriptName) [OPTIONS]
+
+OPTIONS:
+    -Browser NAME       Browser to read the store copy from.
+                        One of: vivaldi, vivaldi-snapshot, brave, chrome,
+                        chromium, edge (default: vivaldi)
+    -BrowserProfile N   Browser profile directory (default: Default)
+    -Source DIR         Read the unpatched extension from DIR instead of
+                        auto-detecting. DIR is the versioned extension folder
+                        containing manifest.json.
+    -Dest DIR           Where to write the patched copy
+                        (default: %USERPROFILE%\claude-vivaldi-patched)
+    -ExtensionId ID     Extension ID to patch
+                        (default: fcoeoabgfenejglbffodgkkbkcdhcgfn)
+    -Check              Report whether the patched copy is up to date with the
+                        installed store copy, then exit.
+                        Exit 0 = up to date, 1 = stale or missing.
+    -Uninstall          Remove the patched copy
+    -DryRun             Show what would happen without writing anything
+    -Quiet              Suppress non-error output
+    -Help               Show this help
+    -Version            Show version
+
+EXAMPLES:
+    # Patch the Vivaldi copy of the extension
+    .\$($script:ScriptName)
+
+    # Preview without writing
+    .\$($script:ScriptName) -DryRun
+
+    # Has the store copy updated since the last patch?
+    .\$($script:ScriptName) -Check
+
+    # Patch a copy installed in a non-default profile
+    .\$($script:ScriptName) -BrowserProfile "Profile 1"
+
+    # Remove the patched copy
+    .\$($script:ScriptName) -Uninstall
+
+AFTER PATCHING:
+    The patched copy must be loaded manually - see the instructions the script
+    prints on success, or the README section "Vivaldi: No active tab".
+"@ | Write-Host
+}
+
+# =============================================================================
+# Environment Detection
+# =============================================================================
+
+function Get-ExtensionsRoot {
+    param([string]$BrowserName)
+
+    $localAppData = $env:LOCALAPPDATA
+    $base = switch ($BrowserName.ToLower()) {
+        "vivaldi"          { Join-Path $localAppData "Vivaldi\User Data" }
+        "vivaldi-snapshot" { Join-Path $localAppData "Vivaldi Snapshot\User Data" }
+        "brave"            { Join-Path $localAppData "BraveSoftware\Brave-Browser\User Data" }
+        "chrome"           { Join-Path $localAppData "Google\Chrome\User Data" }
+        "chromium"         { Join-Path $localAppData "Chromium\User Data" }
+        "edge"             { Join-Path $localAppData "Microsoft\Edge\User Data" }
+        default            { $null }
+    }
+
+    if (-not $base) {
+        Write-ErrorMessage "Unknown browser: $BrowserName"
+        Write-InfoMessage "Use -Source DIR to point at the extension folder directly"
+        return $null
+    }
+
+    return (Join-Path (Join-Path $base $BrowserProfile) "Extensions")
+}
+
+# Highest-versioned folder ("1.0.84_0") under an extension directory
+function Get-LatestVersionDir {
+    param([string]$ExtensionDir)
+
+    $candidates = Get-ChildItem -Path $ExtensionDir -Directory -ErrorAction SilentlyContinue |
+        Where-Object { Test-Path (Join-Path $_.FullName "manifest.json") }
+
+    if (-not $candidates) { return $null }
+
+    $best = $candidates | Sort-Object -Property @{ Expression = {
+        $parts = $_.Name -split '[._]' | ForEach-Object { [int]($_ -replace '\D', '0') }
+        while ($parts.Count -lt 4) { $parts += 0 }
+        [long]"$($parts[0].ToString('00000'))$($parts[1].ToString('00000'))$($parts[2].ToString('00000'))$($parts[3].ToString('00000'))"
+    } } | Select-Object -Last 1
+
+    return $best.FullName
+}
+
+function Resolve-SourceDir {
+    if ($Source) {
+        if (-not (Test-Path (Join-Path $Source "manifest.json"))) {
+            Write-ErrorMessage "No manifest.json in -Source directory: $Source"
+            return $null
+        }
+        return $Source.TrimEnd('\', '/')
+    }
+
+    $extRoot = Get-ExtensionsRoot -BrowserName $Browser
+    if (-not $extRoot) { return $null }
+
+    $extDir = Join-Path $extRoot $ExtensionId
+    if (-not (Test-Path $extDir)) {
+        Write-ErrorMessage "Claude extension not found for $Browser (profile: $BrowserProfile)"
+        Write-InfoMessage "Looked in: $extDir"
+        Write-InfoMessage "Install the Claude extension from the Chrome Web Store first,"
+        Write-InfoMessage "or pass -BrowserProfile / -Source to point at the right location."
+        return $null
+    }
+
+    $latest = Get-LatestVersionDir -ExtensionDir $extDir
+    if (-not $latest) {
+        Write-ErrorMessage "No versioned extension folder with a manifest.json in $extDir"
+        return $null
+    }
+
+    return $latest
+}
+
+# =============================================================================
+# Patch Generation
+# =============================================================================
+
+# The wrapper service worker. MV3 allows exactly one service worker, so the
+# wrapper imports the original untouched and appends listeners to it.
+function Write-WrapperWorker {
+    param([string]$DestFile, [string]$OriginalWorker)
+
+    $content = @"
+// Tab binding for the Claude extension in Chromium forks that ignore
+// chrome.sidePanel.setOptions() - Vivaldi (VB-120826), Arc, and others.
+//
+// Generated by patch-vivaldi.ps1. Do not edit by hand; re-run the script
+// after the store copy updates.
+//
+// Chrome gives the panel its tab through the panel URL
+// (sidepanel.html?tabId=N). Browsers that ignore setOptions() can only load
+// a static URL, so the panel falls back to reading chrome.storage.local
+// "targetTabId" when opened with ?mode=window. Nothing in the stock worker
+// keeps that key current outside the scheduled-task launcher, so it is either
+// missing or stale and every send throws "No active tab".
+//
+// This wrapper loads the original worker unmodified and adds the listeners
+// needed to keep "targetTabId" pointing at the active web tab.
+
+import './$OriginalWorker';
+
+const TARGET_TAB_ID = 'targetTabId';
+
+const isWebTab = (tab) =>
+  !!tab && typeof tab.url === 'string' && /^https?:/i.test(tab.url);
+
+const bind = async (tabId) => {
+  try {
+    const stored = await chrome.storage.local.get(TARGET_TAB_ID);
+    if (stored[TARGET_TAB_ID] === tabId) return;
+    await chrome.storage.local.set({ [TARGET_TAB_ID]: tabId });
+  } catch {
+    // Storage can be unavailable while the worker is shutting down.
+  }
+};
+
+const bindIfWebTab = async (tabId) => {
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    if (isWebTab(tab)) await bind(tabId);
+  } catch {
+    // Tab closed between the event and the lookup.
+  }
+};
+
+// Used on worker wake and window focus, when there is no event tab to use.
+const bindActiveTab = async () => {
+  try {
+    let [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+    if (!isWebTab(tab)) {
+      [tab] = (await chrome.tabs.query({ active: true })).filter(isWebTab);
+    }
+    if (isWebTab(tab)) await bind(tab.id);
+  } catch {
+    // No windows open yet.
+  }
+};
+
+chrome.tabs.onActivated.addListener(({ tabId }) => {
+  void bindIfWebTab(tabId);
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (tab.active && (changeInfo.status === 'complete' || changeInfo.url)) {
+    void bindIfWebTab(tabId);
+  }
+});
+
+chrome.windows.onFocusChanged.addListener((windowId) => {
+  if (windowId !== chrome.windows.WINDOW_ID_NONE) void bindActiveTab();
+});
+
+// Tab IDs are regenerated on browser restart, so re-bind on every cold start
+// rather than waiting for the first tab switch.
+chrome.runtime.onStartup.addListener(() => {
+  void bindActiveTab();
+});
+chrome.runtime.onInstalled.addListener(() => {
+  void bindActiveTab();
+});
+
+void bindActiveTab();
+"@
+
+    # UTF-8 without BOM - a BOM breaks module parsing in Chromium
+    [System.IO.File]::WriteAllText($DestFile, $content, (New-Object System.Text.UTF8Encoding $false))
+}
+
+function Invoke-Patch {
+    $sourceDir = Resolve-SourceDir
+    if (-not $sourceDir) { return $false }
+
+    $manifestPath = Join-Path $sourceDir "manifest.json"
+    $manifest = Get-Content $manifestPath -Raw | ConvertFrom-Json
+
+    $extVersion = $manifest.version
+    $originalWorker = $manifest.background.service_worker
+
+    if (-not $originalWorker) {
+        Write-ErrorMessage "manifest.json has no background.service_worker - nothing to wrap"
+        Write-InfoMessage "Manifest: $manifestPath"
+        return $false
+    }
+
+    if ($originalWorker -eq $script:WrapperWorker) {
+        Write-ErrorMessage "Source is already patched (service_worker is $($script:WrapperWorker))"
+        Write-InfoMessage "Point -Source at the unmodified store copy."
+        return $false
+    }
+
+    Write-InfoMessage "Source:      $sourceDir"
+    Write-InfoMessage "Version:     $extVersion"
+    Write-InfoMessage "Worker:      $originalWorker"
+    Write-InfoMessage "Destination: $Dest"
+    Write-Host ""
+
+    if ($DryRun) {
+        Write-DryRunMessage "Would remove existing $Dest"
+        Write-DryRunMessage "Would copy $sourceDir -> $Dest"
+        Write-DryRunMessage "Would remove $Dest\_metadata"
+        Write-DryRunMessage "Would write $Dest\$($script:WrapperWorker) importing ./$originalWorker"
+        Write-DryRunMessage "Would set background.service_worker=$($script:WrapperWorker), background.type=module"
+        Write-DryRunMessage "Would remove update_url from manifest.json"
+        Write-DryRunMessage "Would write $Dest\$($script:PatchInfo)"
+        Write-Host ""
+        Write-InfoMessage "Dry run complete - nothing was written"
+        return $true
+    }
+
+    if (Test-Path $Dest) {
+        if (-not (Test-Path (Join-Path $Dest "manifest.json"))) {
+            Write-ErrorMessage "Destination exists but does not look like an extension: $Dest"
+            Write-InfoMessage "Refusing to delete it. Choose another -Dest or remove it yourself."
+            return $false
+        }
+        Remove-Item -Path $Dest -Recurse -Force
+    }
+
+    $parent = Split-Path -Parent $Dest
+    if ($parent -and -not (Test-Path $parent)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+
+    Copy-Item -Path $sourceDir -Destination $Dest -Recurse -Force
+    Write-SuccessMessage "Copied extension"
+
+    # _metadata holds Web Store signatures that do not apply to an unpacked copy
+    $metadata = Join-Path $Dest "_metadata"
+    if (Test-Path $metadata) { Remove-Item -Path $metadata -Recurse -Force }
+
+    Write-WrapperWorker -DestFile (Join-Path $Dest $script:WrapperWorker) -OriginalWorker $originalWorker
+    Write-SuccessMessage "Wrote $($script:WrapperWorker) (wraps $originalWorker)"
+
+    $destManifestPath = Join-Path $Dest "manifest.json"
+    $destManifest = Get-Content $destManifestPath -Raw | ConvertFrom-Json
+    $destManifest.background.service_worker = $script:WrapperWorker
+    if ($destManifest.background.PSObject.Properties.Name -contains "type") {
+        $destManifest.background.type = "module"
+    } else {
+        $destManifest.background | Add-Member -MemberType NoteProperty -Name "type" -Value "module"
+    }
+    # Drop update_url so the browser never tries to auto-update an unpacked copy
+    $destManifest.PSObject.Properties.Remove("update_url")
+    $destManifest | ConvertTo-Json -Depth 100 |
+        Set-Content -Path $destManifestPath -Encoding UTF8
+    Write-SuccessMessage "Patched manifest.json"
+
+    # "key" must survive so the unpacked copy keeps the same extension ID and
+    # the native messaging manifests written by setup.ps1 keep matching it.
+    if (-not $destManifest.key) {
+        Write-WarningMessage "manifest.json has no `"key`" - the unpacked copy will get a different"
+        Write-WarningMessage "extension ID, and native messaging will need to be re-registered."
+    }
+
+    $info = [ordered]@{
+        extensionId      = $ExtensionId
+        extensionVersion = $extVersion
+        sourceDir        = $sourceDir
+        browser          = $Browser
+        profile          = $BrowserProfile
+        patcherVersion   = Get-ScriptVersion
+    }
+    $info | ConvertTo-Json | Set-Content -Path (Join-Path $Dest $script:PatchInfo) -Encoding UTF8
+
+    Write-Host ""
+    Show-NextSteps
+    return $true
+}
+
+function Show-NextSteps {
+    if ($Quiet) { return }
+
+    Write-Host "Patched copy ready: $Dest" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "Remaining steps have to be done in the browser:"
+    Write-Host ""
+    Write-Host "  1. Open the browser's extensions page (vivaldi://extensions) and"
+    Write-Host "     disable - do not remove - the Web Store copy of Claude."
+    Write-Host "     Both copies claim ID $ExtensionId, so leaving the store"
+    Write-Host "     copy enabled causes a duplicate-ID error. Keeping it installed but"
+    Write-Host "     disabled lets it keep auto-updating as the source for re-patching."
+    Write-Host ""
+    Write-Host "  2. Turn on Developer mode, click Load unpacked, and select:"
+    Write-Host "       $Dest"
+    Write-Host ""
+    Write-Host "  3. Add the panel with this URL - the query string is required:"
+    Write-Host "       chrome-extension://$ExtensionId/sidepanel.html$($script:PanelQuery)" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "     In Vivaldi: click + in the sidebar (Add Web Panel) and paste it."
+    Write-Host ""
+    Write-Host "Verify from the extension's service worker console:"
+    Write-Host ""
+    Write-Host "    chrome.storage.local.get('targetTabId').then(console.log)"
+    Write-Host ""
+    Write-Host "The value should change as you switch tabs. The panel reads it once, when"
+    Write-Host "the panel document loads, so reload the panel to re-bind it to the current tab."
+    Write-Host ""
+    Write-Host "Re-run this script after the store copy updates:"
+    Write-Host ""
+    Write-Host "    .\$($script:ScriptName) -Check    # is the patched copy stale?"
+    Write-Host "    .\$($script:ScriptName)           # rebuild it"
+}
+
+# =============================================================================
+# Check / Uninstall
+# =============================================================================
+
+function Invoke-Check {
+    if (-not (Test-Path $Dest)) {
+        Write-WarningMessage "No patched copy at $Dest"
+        Write-InfoMessage "Run .\$($script:ScriptName) to create one"
+        return $false
+    }
+
+    $patchedVersion = $null
+    $infoPath = Join-Path $Dest $script:PatchInfo
+    if (Test-Path $infoPath) {
+        $patchedVersion = (Get-Content $infoPath -Raw | ConvertFrom-Json).extensionVersion
+    }
+    if (-not $patchedVersion) {
+        $patchedVersion = (Get-Content (Join-Path $Dest "manifest.json") -Raw | ConvertFrom-Json).version
+    }
+
+    $sourceDir = Resolve-SourceDir
+    if (-not $sourceDir) {
+        Write-WarningMessage "Patched copy is version $patchedVersion, but the store copy could not be found"
+        return $false
+    }
+
+    $storeVersion = (Get-Content (Join-Path $sourceDir "manifest.json") -Raw | ConvertFrom-Json).version
+
+    Write-InfoMessage "Store copy:   $storeVersion  ($sourceDir)"
+    Write-InfoMessage "Patched copy: $patchedVersion  ($Dest)"
+
+    if ($storeVersion -and $storeVersion -eq $patchedVersion) {
+        Write-SuccessMessage "Patched copy is up to date"
+        return $true
+    }
+
+    Write-WarningMessage "Patched copy is stale - re-run .\$($script:ScriptName) to rebuild it"
+    return $false
+}
+
+function Invoke-Uninstall {
+    if (-not (Test-Path $Dest)) {
+        Write-InfoMessage "Nothing to remove - no patched copy at $Dest"
+        return $true
+    }
+
+    if (-not (Test-Path (Join-Path $Dest "manifest.json"))) {
+        Write-ErrorMessage "Refusing to remove $Dest - it does not look like an extension"
+        return $false
+    }
+
+    if ($DryRun) {
+        Write-DryRunMessage "Would remove $Dest"
+        return $true
+    }
+
+    Remove-Item -Path $Dest -Recurse -Force
+    Write-SuccessMessage "Removed $Dest"
+    Write-InfoMessage "Remember to remove the unpacked extension from the browser's"
+    Write-InfoMessage "extensions page and re-enable the Web Store copy."
+    return $true
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+function Invoke-Main {
+    if ($Help) { Show-Help; exit 0 }
+    if ($Version) { Get-ScriptVersion; exit 0 }
+
+    if ($Check -and $Uninstall) {
+        Write-ErrorMessage "-Check and -Uninstall are mutually exclusive"
+        exit 1
+    }
+
+    if (-not $Check) { Write-Header }
+
+    $ok = if ($Uninstall) { Invoke-Uninstall }
+          elseif ($Check) { Invoke-Check }
+          else { Invoke-Patch }
+
+    if (-not $ok) { exit 1 }
+}
+
+Invoke-Main

--- a/patch-vivaldi.sh
+++ b/patch-vivaldi.sh
@@ -1,0 +1,759 @@
+#!/bin/bash
+
+# Claude Extension Tab-Binding Patch for Vivaldi (macOS/Linux)
+#
+# Builds a patched, unpacked copy of the Claude extension for Chromium forks
+# that ignore chrome.sidePanel.setOptions() — Vivaldi (VB-120826), Arc, and
+# friends. Those browsers can only load the panel from a static URL, which
+# leaves the panel with no target tab and makes every message fail with
+# "No active tab".
+#
+# See docs/vivaldi-tab-binding.md for the full analysis.
+#
+# Usage: ./patch-vivaldi.sh [OPTIONS]
+# Run ./patch-vivaldi.sh --help for more information.
+
+set -euo pipefail
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+readonly VERSION_FILE="$SCRIPT_DIR/VERSION"
+
+readonly CLAUDE_OFFICIAL_EXTENSION_ID="fcoeoabgfenejglbffodgkkbkcdhcgfn"
+
+# Name of the wrapper service worker written into the patched copy
+readonly WRAPPER_WORKER="tabbind.js"
+
+# Metadata file recorded in the patched copy (used by --check)
+readonly PATCH_INFO="patch-info.json"
+
+# Query string the panel must be opened with (see docs/vivaldi-tab-binding.md)
+readonly PANEL_QUERY="?mode=window&sessionId=vivaldi-panel"
+
+# Colors for output
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly BLUE='\033[0;34m'
+readonly NC='\033[0m' # No Color
+
+# =============================================================================
+# Global State
+# =============================================================================
+
+BROWSER="vivaldi"
+PROFILE="Default"
+EXTENSION_ID="$CLAUDE_OFFICIAL_EXTENSION_ID"
+SOURCE_DIR=""
+DEST_DIR="$HOME/claude-vivaldi-patched"
+CHECK_MODE=false
+UNINSTALL_MODE=false
+DRY_RUN=false
+VERBOSE=false
+QUIET=false
+OS=""
+JSON_TOOL=""
+EXT_VERSION=""
+
+# =============================================================================
+# Utility Functions
+# =============================================================================
+
+get_version() {
+    if [[ -f "$VERSION_FILE" ]]; then
+        cat "$VERSION_FILE"
+    else
+        echo "unknown"
+    fi
+}
+
+print_header() {
+    if [[ "$QUIET" == true ]]; then return; fi
+    echo ""
+    echo -e "${BLUE}╔════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}║  Claude Extension Tab-Binding Patch (Vivaldi / Arc)        ║${NC}"
+    echo -e "${BLUE}║  Version: $(get_version)                                            ║${NC}"
+    echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+}
+
+print_success() {
+    if [[ "$QUIET" == true ]]; then return; fi
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ $1${NC}" >&2
+}
+
+print_warning() {
+    if [[ "$QUIET" == true ]]; then return; fi
+    echo -e "${YELLOW}⚠ $1${NC}"
+}
+
+print_info() {
+    if [[ "$QUIET" == true ]]; then return; fi
+    echo -e "${BLUE}ℹ $1${NC}"
+}
+
+print_verbose() {
+    if [[ "$VERBOSE" == true ]]; then
+        echo -e "${BLUE}  → $1${NC}"
+    fi
+}
+
+print_dry_run() {
+    echo -e "${YELLOW}[DRY-RUN] $1${NC}"
+}
+
+show_help() {
+    cat <<EOF
+Claude Extension Tab-Binding Patch v$(get_version)
+
+Builds a patched, unpacked copy of the Claude extension so that the side panel
+can resolve a target tab in browsers that ignore chrome.sidePanel.setOptions().
+
+Without this patch the panel renders but every message fails with
+"No active tab" (see docs/vivaldi-tab-binding.md).
+
+USAGE:
+    ./${SCRIPT_NAME} [OPTIONS]
+
+OPTIONS:
+    -b, --browser NAME     Browser to read the store copy from.
+                           One of: vivaldi, vivaldi-snapshot, arc, brave,
+                           chrome, chromium (default: vivaldi)
+    -p, --profile NAME     Browser profile directory (default: Default)
+    -s, --source DIR       Read the unpatched extension from DIR instead of
+                           auto-detecting. DIR is the versioned extension
+                           folder containing manifest.json.
+    -d, --dest DIR         Where to write the patched copy
+                           (default: ~/claude-vivaldi-patched)
+    -e, --extension-id ID  Extension ID to patch
+                           (default: ${CLAUDE_OFFICIAL_EXTENSION_ID})
+    -c, --check            Report whether the patched copy is up to date with
+                           the installed store copy, then exit.
+                           Exit 0 = up to date, 1 = stale or missing.
+    -u, --uninstall        Remove the patched copy
+    -n, --dry-run          Show what would happen without writing anything
+    -v, --verbose          Verbose output
+    -q, --quiet            Suppress non-error output
+    -h, --help             Show this help
+        --version          Show version
+
+EXAMPLES:
+    # Patch the Vivaldi copy of the extension
+    ./${SCRIPT_NAME}
+
+    # Preview without writing
+    ./${SCRIPT_NAME} --dry-run
+
+    # Has the store copy updated since the last patch?
+    ./${SCRIPT_NAME} --check
+
+    # Patch a copy installed in a non-default profile
+    ./${SCRIPT_NAME} --profile "Profile 1"
+
+    # Remove the patched copy
+    ./${SCRIPT_NAME} --uninstall
+
+AFTER PATCHING:
+    The patched copy must be loaded manually, and the panel must be opened at
+
+        chrome-extension://<id>/sidepanel.html${PANEL_QUERY}
+
+    The query string is what lets the panel find its tab — a bare
+    sidepanel.html URL still fails with "No active tab". The script prints the
+    full instructions on success; see also the README section
+    "Vivaldi: No active tab".
+EOF
+}
+
+# =============================================================================
+# Environment Detection
+# =============================================================================
+
+detect_os() {
+    case "$(uname -s)" in
+        Darwin) OS="macos" ;;
+        Linux)  OS="linux" ;;
+        *)
+            print_error "Unsupported OS: $(uname -s)"
+            print_info "Windows users: run patch-vivaldi.ps1 instead"
+            return 1
+            ;;
+    esac
+    print_verbose "Detected OS: $OS"
+}
+
+detect_json_tool() {
+    # PATCH_JSON_TOOL forces a backend; the test suite uses it to exercise
+    # both code paths on a machine that has python3 and jq installed.
+    if [[ -n "${PATCH_JSON_TOOL:-}" ]]; then
+        JSON_TOOL="$PATCH_JSON_TOOL"
+        if ! command -v "$JSON_TOOL" &>/dev/null; then
+            print_error "PATCH_JSON_TOOL=$JSON_TOOL is not installed"
+            return 1
+        fi
+    elif command -v python3 &>/dev/null; then
+        JSON_TOOL="python3"
+    elif command -v jq &>/dev/null; then
+        JSON_TOOL="jq"
+    else
+        print_error "Neither python3 nor jq found — one is required to edit manifest.json"
+        print_info "Install with: brew install jq   (macOS)"
+        print_info "              apt install jq    (Debian/Ubuntu)"
+        return 1
+    fi
+    print_verbose "Using $JSON_TOOL for JSON editing"
+}
+
+# Directory that holds the per-extension folders for a browser profile.
+get_extensions_root() {
+    local browser="$1"
+    local base=""
+
+    if [[ "$OS" == "macos" ]]; then
+        case "$browser" in
+            vivaldi)          base="$HOME/Library/Application Support/Vivaldi" ;;
+            vivaldi-snapshot) base="$HOME/Library/Application Support/Vivaldi Snapshot" ;;
+            arc)              base="$HOME/Library/Application Support/Arc/User Data" ;;
+            brave)            base="$HOME/Library/Application Support/BraveSoftware/Brave-Browser" ;;
+            chrome)           base="$HOME/Library/Application Support/Google/Chrome" ;;
+            chromium)         base="$HOME/Library/Application Support/Chromium" ;;
+            *)
+                print_error "Unknown browser: $browser"
+                print_info "Use --source DIR to point at the extension folder directly"
+                return 1
+                ;;
+        esac
+    else
+        case "$browser" in
+            vivaldi)          base="$HOME/.config/vivaldi" ;;
+            vivaldi-snapshot) base="$HOME/.config/vivaldi-snapshot" ;;
+            brave)            base="$HOME/.config/BraveSoftware/Brave-Browser" ;;
+            chrome)           base="$HOME/.config/google-chrome" ;;
+            chromium)         base="$HOME/.config/chromium" ;;
+            arc)
+                print_error "Arc is not available on Linux"
+                return 1
+                ;;
+            *)
+                print_error "Unknown browser: $browser"
+                print_info "Use --source DIR to point at the extension folder directly"
+                return 1
+                ;;
+        esac
+    fi
+
+    echo "$base/$PROFILE/Extensions"
+}
+
+# Sortable numeric key for a Chrome extension version folder like "1.0.84_0"
+version_key() {
+    printf '%s' "$1" | tr '_' '.' | awk -F. '{printf "%05d%05d%05d%05d", $1+0, $2+0, $3+0, $4+0}'
+}
+
+# Highest-versioned folder under an extension directory that has a manifest.
+find_latest_version_dir() {
+    local ext_dir="$1"
+    local dir name key best="" best_key=""
+
+    for dir in "$ext_dir"/*/; do
+        [[ -f "$dir/manifest.json" ]] || continue
+        name="$(basename "$dir")"
+        key="$(version_key "$name")"
+        if [[ -z "$best_key" || "$key" > "$best_key" ]]; then
+            best_key="$key"
+            best="${dir%/}"
+        fi
+    done
+
+    [[ -n "$best" ]] || return 1
+    echo "$best"
+}
+
+resolve_source_dir() {
+    if [[ -n "$SOURCE_DIR" ]]; then
+        if [[ ! -f "$SOURCE_DIR/manifest.json" ]]; then
+            print_error "No manifest.json in --source directory: $SOURCE_DIR"
+            return 1
+        fi
+        print_verbose "Using explicit source: $SOURCE_DIR"
+        return 0
+    fi
+
+    local ext_root
+    ext_root="$(get_extensions_root "$BROWSER")" || return 1
+    print_verbose "Extensions root: $ext_root"
+
+    if [[ ! -d "$ext_root/$EXTENSION_ID" ]]; then
+        print_error "Claude extension not found for $BROWSER (profile: $PROFILE)"
+        print_info "Looked in: $ext_root/$EXTENSION_ID"
+        print_info "Install the Claude extension from the Chrome Web Store first,"
+        print_info "or pass --profile / --source to point at the right location."
+        return 1
+    fi
+
+    if ! SOURCE_DIR="$(find_latest_version_dir "$ext_root/$EXTENSION_ID")"; then
+        print_error "No versioned extension folder with a manifest.json in $ext_root/$EXTENSION_ID"
+        return 1
+    fi
+
+    print_verbose "Source: $SOURCE_DIR"
+}
+
+# =============================================================================
+# JSON Helpers
+# =============================================================================
+
+# json_field FILE DOTTED.PATH  → value, or empty string
+json_field() {
+    local file="$1" path="$2"
+
+    if [[ "$JSON_TOOL" == "python3" ]]; then
+        JSON_FILE="$file" JSON_PATH="$path" python3 - <<'PY'
+import json, os, sys
+try:
+    with open(os.environ["JSON_FILE"]) as fh:
+        node = json.load(fh)
+except (OSError, ValueError):
+    sys.exit(0)
+for part in os.environ["JSON_PATH"].split("."):
+    if not isinstance(node, dict) or part not in node:
+        sys.exit(0)
+    node = node[part]
+print(node if not isinstance(node, (dict, list)) else "")
+PY
+    else
+        jq -r --arg p "$path" 'getpath($p | split(".")) // "" | if type == "object" or type == "array" then "" else . end' \
+            "$file" 2>/dev/null || true
+    fi
+}
+
+# Rewrite the patched manifest: point the worker at the wrapper, make it a
+# module, and drop update_url so the browser never tries to auto-update an
+# unpacked extension.
+rewrite_manifest() {
+    local file="$1" worker="$2"
+
+    if [[ "$JSON_TOOL" == "python3" ]]; then
+        JSON_FILE="$file" JSON_WORKER="$worker" python3 - <<'PY'
+import json, os
+path = os.environ["JSON_FILE"]
+with open(path) as fh:
+    manifest = json.load(fh)
+manifest.setdefault("background", {})
+manifest["background"]["service_worker"] = os.environ["JSON_WORKER"]
+manifest["background"]["type"] = "module"
+manifest.pop("update_url", None)
+with open(path, "w") as fh:
+    json.dump(manifest, fh, indent=2)
+    fh.write("\n")
+PY
+    else
+        local tmp="$file.tmp"
+        jq --arg w "$worker" \
+            '.background.service_worker = $w | .background.type = "module" | del(.update_url)' \
+            "$file" >"$tmp"
+        mv "$tmp" "$file"
+    fi
+}
+
+write_patch_info() {
+    local file="$1"
+
+    if [[ "$JSON_TOOL" == "python3" ]]; then
+        JSON_FILE="$file" \
+        INFO_SOURCE="$SOURCE_DIR" \
+        INFO_VERSION="$EXT_VERSION" \
+        INFO_BROWSER="$BROWSER" \
+        INFO_PROFILE="$PROFILE" \
+        INFO_EXT_ID="$EXTENSION_ID" \
+        INFO_PATCHER="$(get_version)" \
+        python3 - <<'PY'
+import json, os
+info = {
+    "extensionId": os.environ["INFO_EXT_ID"],
+    "extensionVersion": os.environ["INFO_VERSION"],
+    "sourceDir": os.environ["INFO_SOURCE"],
+    "browser": os.environ["INFO_BROWSER"],
+    "profile": os.environ["INFO_PROFILE"],
+    "patcherVersion": os.environ["INFO_PATCHER"],
+}
+with open(os.environ["JSON_FILE"], "w") as fh:
+    json.dump(info, fh, indent=2)
+    fh.write("\n")
+PY
+    else
+        jq -n \
+            --arg id "$EXTENSION_ID" \
+            --arg version "$EXT_VERSION" \
+            --arg source "$SOURCE_DIR" \
+            --arg browser "$BROWSER" \
+            --arg profile "$PROFILE" \
+            --arg patcher "$(get_version)" \
+            '{extensionId: $id, extensionVersion: $version, sourceDir: $source,
+              browser: $browser, profile: $profile, patcherVersion: $patcher}' \
+            >"$file"
+    fi
+}
+
+# =============================================================================
+# Patch Generation
+# =============================================================================
+
+# The wrapper service worker. MV3 allows exactly one service worker, so the
+# wrapper imports the original untouched and appends listeners to it.
+write_wrapper_worker() {
+    local dest_file="$1" original_worker="$2"
+
+    cat >"$dest_file" <<EOF
+// Tab binding for the Claude extension in Chromium forks that ignore
+// chrome.sidePanel.setOptions() — Vivaldi (VB-120826), Arc, and others.
+//
+// Generated by patch-vivaldi.sh. Do not edit by hand; re-run the script
+// after the store copy updates.
+//
+// Chrome gives the panel its tab through the panel URL
+// (sidepanel.html?tabId=N). Browsers that ignore setOptions() can only load
+// a static URL, so the panel falls back to reading chrome.storage.local
+// "targetTabId" when opened with ?mode=window. Nothing in the stock worker
+// keeps that key current outside the scheduled-task launcher, so it is either
+// missing or stale and every send throws "No active tab".
+//
+// This wrapper loads the original worker unmodified and adds the listeners
+// needed to keep "targetTabId" pointing at the active web tab.
+
+import './${original_worker}';
+
+const TARGET_TAB_ID = 'targetTabId';
+
+const isWebTab = (tab) =>
+  !!tab && typeof tab.url === 'string' && /^https?:/i.test(tab.url);
+
+const bind = async (tabId) => {
+  try {
+    const stored = await chrome.storage.local.get(TARGET_TAB_ID);
+    if (stored[TARGET_TAB_ID] === tabId) return;
+    await chrome.storage.local.set({ [TARGET_TAB_ID]: tabId });
+  } catch {
+    // Storage can be unavailable while the worker is shutting down.
+  }
+};
+
+const bindIfWebTab = async (tabId) => {
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    if (isWebTab(tab)) await bind(tabId);
+  } catch {
+    // Tab closed between the event and the lookup.
+  }
+};
+
+// Used on worker wake and window focus, when there is no event tab to use.
+const bindActiveTab = async () => {
+  try {
+    let [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+    if (!isWebTab(tab)) {
+      [tab] = (await chrome.tabs.query({ active: true })).filter(isWebTab);
+    }
+    if (isWebTab(tab)) await bind(tab.id);
+  } catch {
+    // No windows open yet.
+  }
+};
+
+chrome.tabs.onActivated.addListener(({ tabId }) => {
+  void bindIfWebTab(tabId);
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (tab.active && (changeInfo.status === 'complete' || changeInfo.url)) {
+    void bindIfWebTab(tabId);
+  }
+});
+
+chrome.windows.onFocusChanged.addListener((windowId) => {
+  if (windowId !== chrome.windows.WINDOW_ID_NONE) void bindActiveTab();
+});
+
+// Tab IDs are regenerated on browser restart, so re-bind on every cold start
+// rather than waiting for the first tab switch.
+chrome.runtime.onStartup.addListener(() => {
+  void bindActiveTab();
+});
+chrome.runtime.onInstalled.addListener(() => {
+  void bindActiveTab();
+});
+
+void bindActiveTab();
+EOF
+}
+
+do_patch() {
+    resolve_source_dir || return 1
+    detect_json_tool || return 1
+
+    EXT_VERSION="$(json_field "$SOURCE_DIR/manifest.json" "version")"
+    local original_worker
+    original_worker="$(json_field "$SOURCE_DIR/manifest.json" "background.service_worker")"
+
+    if [[ -z "$original_worker" ]]; then
+        print_error "manifest.json has no background.service_worker — nothing to wrap"
+        print_info "Manifest: $SOURCE_DIR/manifest.json"
+        return 1
+    fi
+
+    if [[ "$original_worker" == "$WRAPPER_WORKER" ]]; then
+        print_error "Source is already patched (service_worker is $WRAPPER_WORKER)"
+        print_info "Point --source at the unmodified store copy."
+        return 1
+    fi
+
+    print_info "Source:      $SOURCE_DIR"
+    print_info "Version:     ${EXT_VERSION:-unknown}"
+    print_info "Worker:      $original_worker"
+    print_info "Destination: $DEST_DIR"
+    echo ""
+
+    if [[ "$DRY_RUN" == true ]]; then
+        print_dry_run "Would remove existing $DEST_DIR"
+        print_dry_run "Would copy $SOURCE_DIR → $DEST_DIR"
+        print_dry_run "Would remove $DEST_DIR/_metadata"
+        print_dry_run "Would write $DEST_DIR/$WRAPPER_WORKER importing ./$original_worker"
+        print_dry_run "Would set background.service_worker=$WRAPPER_WORKER, background.type=module"
+        print_dry_run "Would remove update_url from manifest.json"
+        print_dry_run "Would write $DEST_DIR/$PATCH_INFO"
+        echo ""
+        print_info "Dry run complete — nothing was written"
+        return 0
+    fi
+
+    if [[ -e "$DEST_DIR" ]]; then
+        if [[ ! -d "$DEST_DIR" ]]; then
+            print_error "Destination exists and is not a directory: $DEST_DIR"
+            return 1
+        fi
+        if [[ ! -f "$DEST_DIR/manifest.json" ]]; then
+            print_error "Destination exists but does not look like an extension: $DEST_DIR"
+            print_info "Refusing to delete it. Choose another --dest or remove it yourself."
+            return 1
+        fi
+        print_verbose "Removing previous patched copy: $DEST_DIR"
+        rm -rf "$DEST_DIR"
+    fi
+
+    mkdir -p "$(dirname "$DEST_DIR")"
+    cp -R "$SOURCE_DIR" "$DEST_DIR"
+    print_success "Copied extension ($(du -sh "$DEST_DIR" | cut -f1) )"
+
+    # _metadata holds Web Store signatures that do not apply to an unpacked copy
+    rm -rf "$DEST_DIR/_metadata"
+
+    write_wrapper_worker "$DEST_DIR/$WRAPPER_WORKER" "$original_worker"
+    print_success "Wrote $WRAPPER_WORKER (wraps $original_worker)"
+
+    rewrite_manifest "$DEST_DIR/manifest.json" "$WRAPPER_WORKER"
+    print_success "Patched manifest.json"
+
+    # "key" must survive so the unpacked copy keeps extension ID
+    # $EXTENSION_ID and the native messaging manifests written by setup.sh
+    # keep matching it.
+    if [[ -z "$(json_field "$DEST_DIR/manifest.json" "key")" ]]; then
+        print_warning "manifest.json has no \"key\" — the unpacked copy will get a different"
+        print_warning "extension ID, and native messaging will need to be re-registered."
+    fi
+
+    write_patch_info "$DEST_DIR/$PATCH_INFO"
+    print_verbose "Wrote $PATCH_INFO"
+
+    echo ""
+    print_next_steps
+}
+
+print_next_steps() {
+    if [[ "$QUIET" == true ]]; then return; fi
+
+    local browser_label="Vivaldi"
+    [[ "$BROWSER" == "vivaldi" ]] || browser_label="$BROWSER"
+
+    cat <<EOF
+${GREEN}Patched copy ready:${NC} $DEST_DIR
+
+Remaining steps have to be done in the browser:
+
+  1. Open ${browser_label}'s extensions page (vivaldi://extensions) and
+     ${YELLOW}disable${NC} — do not remove — the Web Store copy of Claude.
+     Both copies claim ID ${EXTENSION_ID}, so leaving the store
+     copy enabled causes a duplicate-ID error. Keeping it installed but
+     disabled lets it keep auto-updating as the source for re-patching.
+
+  2. Turn on ${YELLOW}Developer mode${NC}, click ${YELLOW}Load unpacked${NC}, and select:
+       $DEST_DIR
+
+  3. Add the panel with this URL — the query string is required:
+       ${BLUE}chrome-extension://${EXTENSION_ID}/sidepanel.html${PANEL_QUERY}${NC}
+
+     In Vivaldi: click ${YELLOW}+${NC} in the sidebar (Add Web Panel) and paste it.
+
+Verify from the extension's service worker console:
+
+    chrome.storage.local.get('targetTabId').then(console.log)
+
+The value should change as you switch tabs. The panel reads it once, when the
+panel document loads, so reload the panel to re-bind it to the current tab.
+
+Re-run this script after the store copy updates:
+
+    ./${SCRIPT_NAME} --check    # is the patched copy stale?
+    ./${SCRIPT_NAME}            # rebuild it
+EOF
+}
+
+# =============================================================================
+# Check / Uninstall
+# =============================================================================
+
+do_check() {
+    detect_json_tool || return 1
+
+    if [[ ! -d "$DEST_DIR" ]]; then
+        print_warning "No patched copy at $DEST_DIR"
+        print_info "Run ./${SCRIPT_NAME} to create one"
+        return 1
+    fi
+
+    local patched_version=""
+    if [[ -f "$DEST_DIR/$PATCH_INFO" ]]; then
+        patched_version="$(json_field "$DEST_DIR/$PATCH_INFO" "extensionVersion")"
+    fi
+    if [[ -z "$patched_version" ]]; then
+        patched_version="$(json_field "$DEST_DIR/manifest.json" "version")"
+    fi
+
+    if ! resolve_source_dir; then
+        print_warning "Patched copy is version ${patched_version:-unknown}, but the store copy could not be found"
+        return 1
+    fi
+
+    local store_version
+    store_version="$(json_field "$SOURCE_DIR/manifest.json" "version")"
+
+    print_info "Store copy:   ${store_version:-unknown}  ($SOURCE_DIR)"
+    print_info "Patched copy: ${patched_version:-unknown}  ($DEST_DIR)"
+
+    if [[ -n "$store_version" && "$store_version" == "$patched_version" ]]; then
+        print_success "Patched copy is up to date"
+        return 0
+    fi
+
+    print_warning "Patched copy is stale — re-run ./${SCRIPT_NAME} to rebuild it"
+    return 1
+}
+
+do_uninstall() {
+    if [[ ! -d "$DEST_DIR" ]]; then
+        print_info "Nothing to remove — no patched copy at $DEST_DIR"
+        return 0
+    fi
+
+    if [[ ! -f "$DEST_DIR/manifest.json" ]]; then
+        print_error "Refusing to remove $DEST_DIR — it does not look like an extension"
+        return 1
+    fi
+
+    if [[ "$DRY_RUN" == true ]]; then
+        print_dry_run "Would remove $DEST_DIR"
+        return 0
+    fi
+
+    rm -rf "$DEST_DIR"
+    print_success "Removed $DEST_DIR"
+    print_info "Remember to remove the unpacked extension from the browser's"
+    print_info "extensions page and re-enable the Web Store copy."
+}
+
+# =============================================================================
+# Argument Parsing
+# =============================================================================
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -b|--browser)
+                [[ $# -ge 2 ]] || { print_error "--browser requires a value"; return 1; }
+                BROWSER="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"
+                shift 2
+                ;;
+            -p|--profile)
+                [[ $# -ge 2 ]] || { print_error "--profile requires a value"; return 1; }
+                PROFILE="$2"
+                shift 2
+                ;;
+            -s|--source)
+                [[ $# -ge 2 ]] || { print_error "--source requires a value"; return 1; }
+                SOURCE_DIR="${2%/}"
+                shift 2
+                ;;
+            -d|--dest)
+                [[ $# -ge 2 ]] || { print_error "--dest requires a value"; return 1; }
+                DEST_DIR="${2%/}"
+                shift 2
+                ;;
+            -e|--extension-id)
+                [[ $# -ge 2 ]] || { print_error "--extension-id requires a value"; return 1; }
+                EXTENSION_ID="$2"
+                shift 2
+                ;;
+            -c|--check)     CHECK_MODE=true; shift ;;
+            -u|--uninstall) UNINSTALL_MODE=true; shift ;;
+            -n|--dry-run)   DRY_RUN=true; shift ;;
+            -v|--verbose)   VERBOSE=true; shift ;;
+            -q|--quiet)     QUIET=true; shift ;;
+            -h|--help)      show_help; exit 0 ;;
+            --version)      get_version; exit 0 ;;
+            *)
+                print_error "Unknown option: $1"
+                print_info "Run ./${SCRIPT_NAME} --help for usage"
+                return 1
+                ;;
+        esac
+    done
+
+    if [[ "$CHECK_MODE" == true && "$UNINSTALL_MODE" == true ]]; then
+        print_error "--check and --uninstall are mutually exclusive"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+    parse_args "$@" || exit 1
+
+    if [[ "$CHECK_MODE" != true ]]; then
+        print_header
+    fi
+
+    detect_os || exit 1
+
+    if [[ "$UNINSTALL_MODE" == true ]]; then
+        do_uninstall || exit 1
+    elif [[ "$CHECK_MODE" == true ]]; then
+        do_check || exit 1
+    else
+        do_patch || exit 1
+    fi
+}
+
+# Only run main when executed, so tests can source this file
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/test_patch_vivaldi.sh
+++ b/tests/test_patch_vivaldi.sh
@@ -1,0 +1,451 @@
+#!/bin/bash
+
+# Test suite for the Vivaldi tab-binding patch (Bash)
+# Run with: ./tests/test_patch_vivaldi.sh
+#
+# These tests build patched copies from a synthetic extension fixture, so they
+# never touch a real browser profile.
+
+set -euo pipefail
+
+# =============================================================================
+# Test Framework
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+PATCH_SCRIPT="$PROJECT_DIR/patch-vivaldi.sh"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+TEST_TMP_DIR=""
+FIXTURE_DIR=""
+DEST_DIR=""
+
+# JSON backends to exercise. Populated by detect_json_backends().
+JSON_BACKENDS=()
+
+# =============================================================================
+# Test Utilities
+# =============================================================================
+
+setup_test_environment() {
+    TEST_TMP_DIR=$(mktemp -d)
+    FIXTURE_DIR="$TEST_TMP_DIR/store/fcoeoabgfenejglbffodgkkbkcdhcgfn/1.0.84_0"
+    DEST_DIR="$TEST_TMP_DIR/patched"
+    mkdir -p "$FIXTURE_DIR/assets" "$FIXTURE_DIR/_metadata"
+
+    # Minimal stand-in for the store copy of the Claude extension
+    cat >"$FIXTURE_DIR/manifest.json" <<'JSON'
+{
+  "manifest_version": 3,
+  "name": "Claude",
+  "version": "1.0.84",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8TESTKEY",
+  "update_url": "https://clients2.google.com/service/update2/crx",
+  "background": {
+    "service_worker": "service-worker-loader.js",
+    "type": "module"
+  },
+  "permissions": ["tabs", "storage", "sidePanel"]
+}
+JSON
+    echo "import './assets/service-worker.ts-Db58OdRp.js';" >"$FIXTURE_DIR/service-worker-loader.js"
+    echo "// stub" >"$FIXTURE_DIR/assets/service-worker.ts-Db58OdRp.js"
+    echo "stub" >"$FIXTURE_DIR/_metadata/verified_contents.json"
+
+    # An older version, to prove the highest one wins
+    mkdir -p "$TEST_TMP_DIR/store/fcoeoabgfenejglbffodgkkbkcdhcgfn/1.0.9_0"
+    sed 's/1\.0\.84/1.0.9/' "$FIXTURE_DIR/manifest.json" \
+        >"$TEST_TMP_DIR/store/fcoeoabgfenejglbffodgkkbkcdhcgfn/1.0.9_0/manifest.json"
+
+    echo "Test environment: $TEST_TMP_DIR"
+}
+
+cleanup_test_environment() {
+    if [[ -n "$TEST_TMP_DIR" ]] && [[ -d "$TEST_TMP_DIR" ]]; then
+        rm -rf "$TEST_TMP_DIR"
+    fi
+}
+
+detect_json_backends() {
+    command -v python3 &>/dev/null && JSON_BACKENDS+=("python3")
+    command -v jq &>/dev/null && JSON_BACKENDS+=("jq")
+
+    if [[ ${#JSON_BACKENDS[@]} -eq 0 ]]; then
+        echo -e "${RED}Neither python3 nor jq available — cannot run tests${NC}" >&2
+        exit 1
+    fi
+}
+
+# Run the patch script with the fixture as source
+run_patch() {
+    "$PATCH_SCRIPT" --source "$FIXTURE_DIR" --dest "$DEST_DIR" "$@" 2>&1
+}
+
+# Read a top-level field out of a JSON file, backend-independently
+json_value() {
+    local file="$1" path="$2"
+    if command -v python3 &>/dev/null; then
+        JSON_FILE="$file" JSON_PATH="$path" python3 - <<'PY'
+import json, os, sys
+try:
+    with open(os.environ["JSON_FILE"]) as fh:
+        node = json.load(fh)
+except (OSError, ValueError):
+    sys.exit(0)
+for part in os.environ["JSON_PATH"].split("."):
+    if not isinstance(node, dict) or part not in node:
+        sys.exit(0)
+    node = node[part]
+print(node)
+PY
+    else
+        jq -r --arg p "$path" 'getpath($p | split(".")) // ""' "$file"
+    fi
+}
+
+# Assertions
+assert_equals() {
+    local expected="$1" actual="$2" message="${3:-}"
+    ((TESTS_RUN++)) || true
+    if [[ "$expected" == "$actual" ]]; then
+        ((TESTS_PASSED++)) || true
+        echo -e "${GREEN}PASS${NC}: $message"
+    else
+        ((TESTS_FAILED++)) || true
+        echo -e "${RED}FAIL${NC}: $message"
+        echo -e "  Expected: '$expected'"
+        echo -e "  Actual:   '$actual'"
+    fi
+}
+
+assert_file_exists() {
+    local file="$1"
+    local message="${2:-File should exist: $file}"
+    ((TESTS_RUN++)) || true
+    if [[ -f "$file" ]]; then
+        ((TESTS_PASSED++)) || true
+        echo -e "${GREEN}PASS${NC}: $message"
+    else
+        ((TESTS_FAILED++)) || true
+        echo -e "${RED}FAIL${NC}: $message (file does not exist)"
+    fi
+}
+
+assert_not_exists() {
+    local path="$1"
+    local message="${2:-Path should not exist: $path}"
+    ((TESTS_RUN++)) || true
+    if [[ ! -e "$path" ]]; then
+        ((TESTS_PASSED++)) || true
+        echo -e "${GREEN}PASS${NC}: $message"
+    else
+        ((TESTS_FAILED++)) || true
+        echo -e "${RED}FAIL${NC}: $message (path exists)"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" message="${3:-String should contain substring}"
+    ((TESTS_RUN++)) || true
+    if [[ "$haystack" == *"$needle"* ]]; then
+        ((TESTS_PASSED++)) || true
+        echo -e "${GREEN}PASS${NC}: $message"
+    else
+        ((TESTS_FAILED++)) || true
+        echo -e "${RED}FAIL${NC}: $message"
+        echo -e "  Looking for: '$needle'"
+        echo -e "  In: '$haystack'"
+    fi
+}
+
+assert_exit_code() {
+    local expected="$1" actual="$2" message="${3:-}"
+    ((TESTS_RUN++)) || true
+    if [[ "$expected" == "$actual" ]]; then
+        ((TESTS_PASSED++)) || true
+        echo -e "${GREEN}PASS${NC}: $message"
+    else
+        ((TESTS_FAILED++)) || true
+        echo -e "${RED}FAIL${NC}: $message (expected exit $expected, got $actual)"
+    fi
+}
+
+# =============================================================================
+# Script Sanity Tests
+# =============================================================================
+
+test_script_exists_and_is_executable() {
+    assert_file_exists "$PATCH_SCRIPT" "patch-vivaldi.sh exists"
+    ((TESTS_RUN++)) || true
+    if [[ -x "$PATCH_SCRIPT" ]]; then
+        ((TESTS_PASSED++)) || true
+        echo -e "${GREEN}PASS${NC}: patch-vivaldi.sh is executable"
+    else
+        ((TESTS_FAILED++)) || true
+        echo -e "${RED}FAIL${NC}: patch-vivaldi.sh is not executable"
+    fi
+}
+
+test_help_lists_options() {
+    local output
+    output=$("$PATCH_SCRIPT" --help)
+    assert_contains "$output" "--check" "Help documents --check"
+    assert_contains "$output" "--uninstall" "Help documents --uninstall"
+    assert_contains "$output" "--dry-run" "Help documents --dry-run"
+    assert_contains "$output" "mode=window" "Help or usage references the panel URL mode"
+}
+
+test_unknown_option_fails() {
+    local code=0
+    "$PATCH_SCRIPT" --not-a-real-option >/dev/null 2>&1 || code=$?
+    assert_exit_code "1" "$code" "Unknown option exits 1"
+}
+
+test_check_and_uninstall_are_exclusive() {
+    local code=0
+    "$PATCH_SCRIPT" --check --uninstall >/dev/null 2>&1 || code=$?
+    assert_exit_code "1" "$code" "--check with --uninstall exits 1"
+}
+
+test_missing_source_fails() {
+    local code=0
+    "$PATCH_SCRIPT" --source "$TEST_TMP_DIR/nonexistent" --dest "$DEST_DIR" >/dev/null 2>&1 || code=$?
+    assert_exit_code "1" "$code" "Nonexistent --source exits 1"
+}
+
+# =============================================================================
+# Dry-Run Tests
+# =============================================================================
+
+test_dry_run_writes_nothing() {
+    rm -rf "$DEST_DIR"
+    local output
+    output=$(run_patch --dry-run)
+    assert_contains "$output" "[DRY-RUN]" "Dry run is labelled"
+    assert_not_exists "$DEST_DIR" "Dry run creates no destination directory"
+}
+
+# =============================================================================
+# Patch Output Tests (run against every available JSON backend)
+# =============================================================================
+
+test_patch_output() {
+    local backend="$1"
+    rm -rf "$DEST_DIR"
+
+    PATCH_JSON_TOOL="$backend" run_patch --quiet >/dev/null
+
+    assert_file_exists "$DEST_DIR/manifest.json" "[$backend] manifest.json copied"
+    assert_file_exists "$DEST_DIR/tabbind.js" "[$backend] tabbind.js written"
+    assert_file_exists "$DEST_DIR/service-worker-loader.js" "[$backend] original worker preserved"
+    assert_not_exists "$DEST_DIR/_metadata" "[$backend] _metadata removed"
+
+    assert_equals "tabbind.js" \
+        "$(json_value "$DEST_DIR/manifest.json" "background.service_worker")" \
+        "[$backend] service_worker points at the wrapper"
+    assert_equals "module" \
+        "$(json_value "$DEST_DIR/manifest.json" "background.type")" \
+        "[$backend] background.type is module"
+    assert_equals "" \
+        "$(json_value "$DEST_DIR/manifest.json" "update_url")" \
+        "[$backend] update_url removed"
+    assert_equals "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8TESTKEY" \
+        "$(json_value "$DEST_DIR/manifest.json" "key")" \
+        "[$backend] key preserved (extension ID is stable)"
+    assert_equals "1.0.84" \
+        "$(json_value "$DEST_DIR/manifest.json" "version")" \
+        "[$backend] version untouched"
+
+    local wrapper
+    wrapper=$(cat "$DEST_DIR/tabbind.js")
+    assert_contains "$wrapper" "import './service-worker-loader.js';" \
+        "[$backend] wrapper imports the original worker by its manifest name"
+    assert_contains "$wrapper" "chrome.tabs.onActivated" \
+        "[$backend] wrapper listens for tab activation"
+    assert_contains "$wrapper" "chrome.runtime.onStartup" \
+        "[$backend] wrapper re-binds on browser start"
+    assert_contains "$wrapper" "targetTabId" \
+        "[$backend] wrapper writes the targetTabId key"
+
+    assert_equals "1.0.84" \
+        "$(json_value "$DEST_DIR/patch-info.json" "extensionVersion")" \
+        "[$backend] patch-info records the source version"
+}
+
+test_repatch_is_idempotent() {
+    rm -rf "$DEST_DIR"
+    run_patch --quiet >/dev/null
+    local first
+    first=$(cat "$DEST_DIR/tabbind.js")
+
+    run_patch --quiet >/dev/null
+    assert_equals "$first" "$(cat "$DEST_DIR/tabbind.js")" \
+        "Re-running the patch over an existing copy produces the same wrapper"
+    assert_equals "tabbind.js" \
+        "$(json_value "$DEST_DIR/manifest.json" "background.service_worker")" \
+        "Re-running does not double-wrap the worker"
+}
+
+test_patched_copy_is_rejected_as_source() {
+    rm -rf "$DEST_DIR"
+    run_patch --quiet >/dev/null
+
+    local code=0 output
+    output=$("$PATCH_SCRIPT" --source "$DEST_DIR" --dest "$TEST_TMP_DIR/twice" 2>&1) || code=$?
+    assert_exit_code "1" "$code" "Using an already-patched copy as source exits 1"
+    assert_contains "$output" "already patched" "Error explains the copy is already patched"
+}
+
+test_refuses_to_delete_non_extension_dest() {
+    local junk="$TEST_TMP_DIR/junk"
+    mkdir -p "$junk"
+    echo "important" >"$junk/notes.txt"
+
+    local code=0
+    "$PATCH_SCRIPT" --source "$FIXTURE_DIR" --dest "$junk" >/dev/null 2>&1 || code=$?
+    assert_exit_code "1" "$code" "Refuses a destination that is not an extension"
+    assert_file_exists "$junk/notes.txt" "Non-extension destination left untouched"
+}
+
+# =============================================================================
+# Version Selection / Check / Uninstall Tests
+# =============================================================================
+
+test_picks_highest_version() {
+    rm -rf "$DEST_DIR"
+    local output
+    output=$("$PATCH_SCRIPT" \
+        --source "$TEST_TMP_DIR/store/fcoeoabgfenejglbffodgkkbkcdhcgfn/1.0.84_0" \
+        --dest "$DEST_DIR" --dry-run)
+    assert_contains "$output" "1.0.84" "Explicit source reports its own version"
+
+    # 1.0.84_0 must sort above 1.0.9_0 (numeric, not lexicographic)
+    ((TESTS_RUN++)) || true
+    local key_84 key_9
+    key_84=$(printf '%s' "1.0.84_0" | tr '_' '.' | awk -F. '{printf "%05d%05d%05d%05d", $1+0, $2+0, $3+0, $4+0}')
+    key_9=$(printf '%s' "1.0.9_0" | tr '_' '.' | awk -F. '{printf "%05d%05d%05d%05d", $1+0, $2+0, $3+0, $4+0}')
+    if [[ "$key_84" > "$key_9" ]]; then
+        ((TESTS_PASSED++)) || true
+        echo -e "${GREEN}PASS${NC}: Version 1.0.84 sorts above 1.0.9"
+    else
+        ((TESTS_FAILED++)) || true
+        echo -e "${RED}FAIL${NC}: Version 1.0.84 should sort above 1.0.9"
+    fi
+}
+
+test_check_reports_up_to_date() {
+    rm -rf "$DEST_DIR"
+    run_patch --quiet >/dev/null
+
+    local code=0 output
+    output=$("$PATCH_SCRIPT" --source "$FIXTURE_DIR" --dest "$DEST_DIR" --check 2>&1) || code=$?
+    assert_exit_code "0" "$code" "--check exits 0 when the patched copy matches"
+    assert_contains "$output" "up to date" "--check says the copy is up to date"
+}
+
+test_check_detects_drift() {
+    rm -rf "$DEST_DIR"
+    run_patch --quiet >/dev/null
+
+    # Simulate the store copy updating underneath the patched copy
+    local newer="$TEST_TMP_DIR/store/fcoeoabgfenejglbffodgkkbkcdhcgfn/1.0.85_0"
+    mkdir -p "$newer"
+    sed 's/1\.0\.84/1.0.85/' "$FIXTURE_DIR/manifest.json" >"$newer/manifest.json"
+    cp "$FIXTURE_DIR/service-worker-loader.js" "$newer/"
+
+    local code=0 output
+    output=$("$PATCH_SCRIPT" --source "$newer" --dest "$DEST_DIR" --check 2>&1) || code=$?
+    assert_exit_code "1" "$code" "--check exits 1 when the store copy is newer"
+    assert_contains "$output" "stale" "--check says the copy is stale"
+}
+
+test_check_without_patched_copy() {
+    local code=0
+    "$PATCH_SCRIPT" --source "$FIXTURE_DIR" --dest "$TEST_TMP_DIR/absent" --check >/dev/null 2>&1 || code=$?
+    assert_exit_code "1" "$code" "--check exits 1 when there is no patched copy"
+}
+
+test_uninstall_removes_patched_copy() {
+    rm -rf "$DEST_DIR"
+    run_patch --quiet >/dev/null
+
+    "$PATCH_SCRIPT" --dest "$DEST_DIR" --uninstall --quiet >/dev/null
+    assert_not_exists "$DEST_DIR" "--uninstall removes the patched copy"
+}
+
+test_uninstall_refuses_non_extension_dir() {
+    local junk="$TEST_TMP_DIR/junk2"
+    mkdir -p "$junk"
+    echo "important" >"$junk/notes.txt"
+
+    local code=0
+    "$PATCH_SCRIPT" --dest "$junk" --uninstall >/dev/null 2>&1 || code=$?
+    assert_exit_code "1" "$code" "--uninstall refuses a non-extension directory"
+    assert_file_exists "$junk/notes.txt" "Non-extension directory left untouched"
+}
+
+# =============================================================================
+# Test Runner
+# =============================================================================
+
+run_tests() {
+    echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BLUE}  Vivaldi Tab-Binding Patch Test Suite${NC}"
+    echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+
+    detect_json_backends
+    echo "JSON backends under test: ${JSON_BACKENDS[*]}"
+    setup_test_environment
+    trap cleanup_test_environment EXIT
+
+    echo -e "\n${BLUE}Running Script Sanity Tests...${NC}"
+    test_script_exists_and_is_executable
+    test_help_lists_options
+    test_unknown_option_fails
+    test_check_and_uninstall_are_exclusive
+    test_missing_source_fails
+
+    echo -e "\n${BLUE}Running Dry-Run Tests...${NC}"
+    test_dry_run_writes_nothing
+
+    echo -e "\n${BLUE}Running Patch Output Tests...${NC}"
+    local backend
+    for backend in "${JSON_BACKENDS[@]}"; do
+        test_patch_output "$backend"
+    done
+    test_repatch_is_idempotent
+    test_patched_copy_is_rejected_as_source
+    test_refuses_to_delete_non_extension_dest
+
+    echo -e "\n${BLUE}Running Version / Check / Uninstall Tests...${NC}"
+    test_picks_highest_version
+    test_check_reports_up_to_date
+    test_check_detects_drift
+    test_check_without_patched_copy
+    test_uninstall_removes_patched_copy
+    test_uninstall_refuses_non_extension_dir
+
+    echo ""
+    echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+    echo -e "Tests run: $TESTS_RUN"
+    echo -e "${GREEN}Passed: $TESTS_PASSED${NC}"
+    echo -e "${RED}Failed: $TESTS_FAILED${NC}"
+    echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+
+    if [[ "$TESTS_FAILED" -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+run_tests


### PR DESCRIPTION
## What

Adds `patch-vivaldi.sh` / `patch-vivaldi.ps1`, which fix the `No active tab` error that makes the README's Vivaldi Web Panel workaround render a panel that can't send anything.

## Why

Following the current README workaround, the panel renders completely — chat UI, login, native messaging all work. Typing a message and pressing Enter clears the composer and nothing happens. The panel console shows:

```
Uncaught (in promise) Error: No active tab
    at assets/sidepanel-<hash>.js
```

The panel resolves its target tab from exactly two sources:

```js
const e = new URLSearchParams(window.location.search), i = e.get("tabId");
let o;
if (i) {
  o = parseInt(i);
} else if ("window" === e.get("mode")) {
  const e = await $(A.TARGET_TAB_ID);   // chrome.storage.local, key "targetTabId"
  e && (o = e);
}
s(o);
```

Two branches, no fallback. In Chrome the service worker injects the tab ID into the panel URL per tab:

```js
chrome.sidePanel.setOptions({ tabId: e, path: `sidepanel.html?tabId=${e}`, enabled: true });
```

Vivaldi ignores `setOptions()` (VB-120826), and a Web Panel URL is a frozen string with no query parameters. So `tabId` is absent, `mode` is absent, the tab ID stays `undefined`, and the send path throws on `if (!l) throw new Error("No active tab")`.

The `mode=window` branch is a real, usable code path — but the stock service worker writes `targetTabId` in exactly one place (the scheduled-task launcher) and nothing keeps it current. There's no `tabs.onActivated` listener anywhere in the worker bundle. That gap is the whole bug.

Notably this also affects the static `side_panel.default_path` manifest approach ([bigbrojake/claude-extension-vivaldi-fix](https://github.com/bigbrojake/claude-extension-vivaldi-fix)) — it fixes the blank panel and then lands on this.

## How

The scripts build a patched, unpacked copy of the extension:

- **`tabbind.js`** wraps the original service worker. MV3 allows exactly one worker, so it `import`s the original untouched and appends the missing listeners (`tabs.onActivated`, `tabs.onUpdated`, `windows.onFocusChanged`, `runtime.onStartup`, plus a bind on every worker wake since tab IDs are regenerated on restart). A `https?:` guard keeps it from binding to `vivaldi://` or blank tabs.
- **`manifest.json`** is repointed at the wrapper; `update_url` and `_metadata/` are dropped so the browser doesn't try to auto-update or verify an unpacked copy.
- **`"key"` is preserved**, so the unpacked copy keeps ID `fcoeoabgfenejglbffodgkkbkcdhcgfn` and the native messaging manifests written by `setup.sh` keep matching — no reconfiguration.

The panel is then opened at `sidepanel.html?mode=window&sessionId=vivaldi-panel`.

The worker filename is read from `manifest.json` rather than hardcoding a build hash, so re-running after an extension update just works. `--check` reports drift, `--uninstall` removes the patched copy.

Three steps still have to be done by hand (disable the store copy, load unpacked, add the Web Panel) — documented in both the README and the script's success output.

## Also in this PR

- `docs/vivaldi-tab-binding.md` — full root-cause analysis, ruled-out hypotheses, design notes, verification steps
- README: Vivaldi rows and troubleshooting rewritten; the Web Panel section now says explicitly that it fixes rendering only
- `tests/test_patch_vivaldi.sh` — 55 tests against a synthetic extension fixture (no real browser profile touched), exercising both the python3 and jq JSON backends
- CHANGELOG and TESTING updated

## Testing

- `./tests/test_patch_vivaldi.sh` → 55/55 pass
- `shellcheck patch-vivaldi.sh tests/test_patch_vivaldi.sh` → clean apart from the two SC2155 warnings that `setup.sh` already has for the same `readonly SCRIPT_DIR=$(...)` idiom
- Verified end-to-end against the real store copy on macOS (Vivaldi stable, Claude extension 1.0.84): both JSON backends produce byte-identical wrappers, patched manifest is valid, `tabbind.js` parses as an ES module, `--check`/`--uninstall` behave

## Credit

The diagnosis is a user's — they traced it through the deminified bundle and confirmed the fix on macOS. I re-verified every claim against the installed extension (1.0.84) before implementing.

## Upstream

The real fix is three lines in the extension — a third fallback branch in the resolver:

```js
else { const [t] = await chrome.tabs.query({active:true, currentWindow:true}); o = t?.id; }
```

`currentWindow` demonstrably resolves correctly from the panel document context in Vivaldi. That would fix Vivaldi, Arc, and every other fork at once and make this patch unnecessary. Worth filing at `anthropics/claude-code` — happy to do that as a follow-up.

## One known caveat

The panel reads `targetTabId` once, at mount — there's no `storage.onChanged` listener for that key in the panel bundle. So the patch guarantees a panel loaded *now* binds to the tab active *now*; it doesn't retarget an already-open panel. Reload the Web Panel to re-bind. This mirrors Chrome, where the side panel is per-tab by construction. Documented as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)